### PR TITLE
Updated for base version Steelseries Arctis Nova 5

### DIFF
--- a/src/headphone_models.rs
+++ b/src/headphone_models.rs
@@ -205,13 +205,13 @@ pub const KNOWN_HEADPHONES: &[HeadphoneModel] = &[
     HeadphoneModel {
         name: "Arctis Nova 5",
         product_id: 0x2232,
-        write_bytes: [0x00, 0xB0],
+        write_bytes: [0x00, 0xb0],
         interface_num: Some(3),
-        battery_percent_idx: 0x03,
-        charging_status_idx: Some(0x04),
+        battery_percent_idx: 3,
+        charging_status_idx: Some(4),
         usage_page_and_id: Some((0xffc0, 0x1)),
-        read_buf_size: 128,
-        battery_range: (0x00, 0x04),
+        read_buf_size: 64,
+        battery_range: (0x00, 0x64),
     },
     HeadphoneModel {
         name: "Arctis Nova 5X",

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -234,3 +234,12 @@ impl std::fmt::Debug for HeadphoneModel {
             .finish_non_exhaustive()
     }
 }
+
+impl Headphone {
+    // ...existing methods...
+
+    /// Returns the (min, max) range of expected battery values
+    pub fn battery_range(&self) -> (u8, u8) {
+        self.model.battery_range
+    }
+}


### PR DESCRIPTION
Fixed `HeadphoneModel` for Arctis Nova 5.

Updated `lib.rs` as the Arctis Nova 5 headphones sends accurate battery levels from 0-100 instead of the usual 0/25/50/75/100. The original code doesn't know what battery icon to display on the battery icon now that the device sends accurate battery levels.

Should still be working for the older models but I have no way of testing it on my end.