### PR TITLE
Update default battery range and fix fully charged state for Arctis 9

### DIFF
--- a/src/headphone_models.rs
+++ b/src/headphone_models.rs
@@ -73,7 +73,7 @@ pub const KNOWN_HEADPHONES: &[HeadphoneModel] = &[
         connected_status_idx: Some(1),
         usage_page_and_id: None,
         read_buf_size: 12,
-        battery_range: (0x64, 0x9a),
+        battery_range: (0x64, 0xa5),
     },
     HeadphoneModel {
         name: "Arctis 1 Wireless",

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -114,6 +114,7 @@ impl Headphone {
                         match buf[charging_status_idx] {
                             0 => Some(ChargingState::Connected),
                             1 => Some(ChargingState::Charging),
+                            2 => Some(ChargingState::Charging), // charging but fully charged
                             _ => {
                                 debug!(
                                     "Returned charge state is invalid: {:x}; ignoring",


### PR DESCRIPTION
Updated the default range for Arctis 9 in headphone_models.rs
and support charging state = 2 which is plugged in, fully charged